### PR TITLE
RPO-2858: Update Concert prebid adapter to pass along top-line page referer 

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -58,7 +58,7 @@ export const spec = {
         adSlot: bidRequest.params.slot || bidRequest.adUnitCode,
         placementId: bidRequest.params.placementId || '',
         site: bidRequest.params.site || bidderRequest.refererInfo.page,
-        ref: bidderRequest.refererInfo.ref || bidderRequest.refererInfo.topmostLocation
+        ref: bidderRequest.refererInfo.ref || window.document.referrer
       };
 
       return slot;


### PR DESCRIPTION
### Description

[RPO-2858: Update Concert prebid adapter to pass along top-line page referer](https://vmproduct.atlassian.net/browse/RPO-2858)

> Prebid supports the ability to pass along the page referer domain information along with the bid request.

### Detailed changes

This PR contains an addition of a `ref` property to the slots, populated by `bidderRequest.refererInfo.ref` (with ~`bidderRequest.refererInfo.topmostLocation`~ `window.document.referrer` as a fallback value).

(It also contains some `;` and whitespace linting-style fixups, as one of the commits; just go here for the non-lint change: https://github.com/voxmedia/Prebid.js/commit/9994aa951bdf4500da3fc9b229161726013a2adc )

### Notes

~The fallback value is just my proposed suggestion; waiting for feedback/approval from Blaine:~ https://vmproduct.atlassian.net/browse/RPO-2858?focusedCommentId=93152
