### PR TITLE
[RPO-2922] - Add Prebid Unified Token

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -34,6 +34,9 @@ export const spec = {
   buildRequests: function(validBidRequests, bidderRequest) {
     logMessage(validBidRequests);
     logMessage(bidderRequest);
+
+    const eids = [];
+
     let payload = {
       meta: {
         prebidVersion: '$prebid.version$',
@@ -49,6 +52,8 @@ export const spec = {
     };
 
     payload.slots = validBidRequests.map(bidRequest => {
+      collectEid(eids, bidRequest);
+
       let slot = {
         name: bidRequest.adUnitCode,
         bidId: bidRequest.bidId,
@@ -64,6 +69,8 @@ export const spec = {
 
       return slot;
     });
+
+    payload.meta.eids = eids.filter(Boolean);
 
     logMessage(payload);
 
@@ -215,4 +222,26 @@ function consentAllowsPpid(bidderRequest) {
   const gdprConsent = bidderRequest?.gdprConsent && hasPurpose1Consent(bidderRequest?.gdprConsent);
 
   return (uspConsent || gdprConsent);
+}
+
+function collectEid(eids, bid) {
+  if (bid.userId) {
+    const eid = getUserId(bid.userId.uid2 && bid.userId.uid2.id, 'uidapi.com', undefined, 3)
+    eids.push(eid)
+  }
+}
+
+function getUserId(id, source, uidExt, atype) {
+  if (id) {
+    const uid = { id, atype };
+
+    if (uidExt) {
+      uid.ext = uidExt;
+    }
+
+    return {
+      source,
+      uids: [ uid ]
+    };
+  }
 }

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -119,6 +119,27 @@ describe('ConcertAdapter', function () {
 
       expect(payload.meta.uid).to.equal('foo');
     });
+
+    it('should add uid2 to eids list if available', function() {
+      bidRequests[0].userId = { uid2: { id: 'uid123' } }
+
+      const request = spec.buildRequests(bidRequests, bidRequest);
+      const payload = JSON.parse(request.data);
+      const meta = payload.meta
+
+      expect(meta.eids.length).to.equal(1);
+      expect(meta.eids[0].uids[0].id).to.equal('uid123')
+      expect(meta.eids[0].uids[0].atype).to.equal(3)
+    })
+
+    it('should return empty eids list if none are available', function() {
+      bidRequests[0].userId = { testId: { id: 'uid123' } }
+      const request = spec.buildRequests(bidRequests, bidRequest);
+      const payload = JSON.parse(request.data);
+      const meta = payload.meta
+
+      expect(meta.eids.length).to.equal(0);
+    })
   });
 
   describe('spec.interpretResponse', function() {


### PR DESCRIPTION
### Description
[RPO-2922: Add Prebid Unified token](https://vmproduct.atlassian.net/browse/RPO-2922)

 Support the passing of the Prebid unified ID 2.0 token to our bid adapter

### Detailed changes
This PR adds the ORTB specification for EIDS, which will include the prebid unified token when present. Only this specific ID will be sent until we decided to support other EIDs.
