### PR TITLE
[RPO-2971] - Add ad slot positioning to payload

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -53,6 +53,8 @@ export const spec = {
 
     payload.slots = validBidRequests.map(bidRequest => {
       collectEid(eids, bidRequest);
+      const adUnitElement = document.getElementById(bidRequest.adUnitCode)
+      const coordinates = getOffset(adUnitElement)
 
       let slot = {
         name: bidRequest.adUnitCode,
@@ -64,8 +66,9 @@ export const spec = {
         adSlot: bidRequest.params.slot || bidRequest.adUnitCode,
         placementId: bidRequest.params.placementId || '',
         site: bidRequest.params.site || bidderRequest.refererInfo.page,
-        ref: bidderRequest.refererInfo.ref
-      };
+        ref: bidderRequest.refererInfo.ref,
+        offsetCoordinates: { x: coordinates?.left, y: coordinates?.top }
+      }
 
       return slot;
     });
@@ -242,6 +245,16 @@ function getUserId(id, source, uidExt, atype) {
     return {
       source,
       uids: [ uid ]
+    };
+  }
+}
+
+function getOffset(el) {
+  if (el) {
+    const rect = el.getBoundingClientRect();
+    return {
+      left: rect.left + window.scrollX,
+      top: rect.top + window.scrollY
     };
   }
 }


### PR DESCRIPTION
### Description

[RPO-2971 - Add ad slot position to request](https://vmproduct.atlassian.net/browse/RPO-2971)

### Detailed Changes

This PR adds the coordinates of a given ad slot for enhanced view-ability predictions. The coordinates returned will be where the ad slot is relative to the entire page.

### Questions / Concerns
- Will the positioning for an ad slot on the page be enough to meet our needs? Do we need to know if the ad slot is visible or not?
- Will this method of gathering coordinates work regardless of render context? ie. iframe, SafeFrame
----------------------------
### Post Test Update
- Testing this feature in a sandbox environment was an onerous task, and I exceeded my time box. I tested it on this [site](https://www.bustle.com/entertainment/is-kelly-dating-anyone-after-bling-empire-boyfriend?pbjs_debug=true) using the console with bids from Prebid. If someone knows of a better way to test this please let me know, but in the meantime, I'll gather my notes and open a Tech Debt ticket to improve this process.

![image](https://user-images.githubusercontent.com/11672791/194566854-dcb98ac3-dd49-4915-8e46-fbcda4fbb59e.png)
![image](https://user-images.githubusercontent.com/11672791/194566891-2fd12cec-c5cb-49fc-86c1-88e84752861a.png)

- If the ad unit is stored in the ID of the element we should have no trouble querying and getting the offset. Problems arise, however, when we don’t know where the `ad_unit` comes from or where it lives in the DOM. I’ve seen other adapters do what we are attempting to do, but there is only one way to find out.