### PR TITLE
RPO-2012: Update local storage name-spacing for c_uid

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -188,11 +188,19 @@ function getUid(bidderRequest) {
     return false;
   }
 
-  const CONCERT_UID_KEY = 'c_uid';
+  const LEGACY_CONCERT_UID_KEY = 'c_uid';
+  const CONCERT_UID_KEY = 'vmconcert_uid';
 
+  const legacyUid = storage.getDataFromLocalStorage(LEGACY_CONCERT_UID_KEY);
   let uid = storage.getDataFromLocalStorage(CONCERT_UID_KEY);
 
-  if (!uid) {
+  if (legacyUid) {
+    uid = legacyUid;
+    storage.setDataInLocalStorage(CONCERT_UID_KEY, uid);
+    storage.removeDataFromLocalStorage(LEGACY_CONCERT_UID_KEY);
+  }
+
+  if (!legacyUid && !uid) {
     uid = generateUUID();
     storage.setDataInLocalStorage(CONCERT_UID_KEY, uid);
   }

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -200,7 +200,7 @@ function getUid(bidderRequest) {
     storage.removeDataFromLocalStorage(LEGACY_CONCERT_UID_KEY);
   }
 
-  if (!legacyUid && !uid) {
+  if (!uid) {
     uid = generateUUID();
     storage.setDataInLocalStorage(CONCERT_UID_KEY, uid);
   }


### PR DESCRIPTION
### Description

[Jira Ticket](https://vmproduct.atlassian.net/browse/RPO-2012?atlOrigin=eyJpIjoiOGFjMmE3YzVmMDJlNDQ5YmE3OTFjOWIzMDVmY2EwNmMiLCJwIjoiaiJ9)

### Detailed Changes

This PR improves the name-spacing we use in local storage for keeping track of the user ID to be more specific and to avoid potential collisions with vendors. A check has been added to see if a value for the legacy `c_uid` key exists and replaces it with `vmconcert_uid` if so. If neither the legacy or the new key/value exists, we generate a new uid. 

### Questions
- Does this need to be duplicated for prebid within concert-ads [here](https://github.com/voxmedia/concert-ads/blob/c6c1ef2de7d624cbc0ad575c6cd5f27d5bf36309/src/vendor/prebid-v2/concertBidAdapter.js#L176) and [here](https://github.com/voxmedia/concert-ads/blob/c6c1ef2de7d624cbc0ad575c6cd5f27d5bf36309/src/vendor/prebid-v3/concertBidAdapter.js#L182)?
- 