### PR TITLE
RPO-2012: Update local storage name-spacing for c_uid

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -188,9 +188,17 @@ function getUid(bidderRequest) {
     return false;
   }
 
-  const CONCERT_UID_KEY = 'c_uid';
+  const LEGACY_CONCERT_UID_KEY = 'c_uid';
+  const CONCERT_UID_KEY = 'vmconcert_uid';
 
+  const legacyUid = storage.getDataFromLocalStorage(LEGACY_CONCERT_UID_KEY);
   let uid = storage.getDataFromLocalStorage(CONCERT_UID_KEY);
+
+  if (legacyUid) {
+    uid = legacyUid;
+    storage.setDataInLocalStorage(CONCERT_UID_KEY, uid);
+    storage.removeDataFromLocalStorage(LEGACY_CONCERT_UID_KEY);
+  }
 
   if (!uid) {
     uid = generateUUID();

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -178,7 +178,7 @@ export const spec = {
 
 registerBidder(spec);
 
-const storage = getStorageManager({bidderCode: BIDDER_CODE});
+export const storage = getStorageManager({bidderCode: BIDDER_CODE});
 
 /**
  * Check or generate a UID for the current user.

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { spec } from 'modules/concertBidAdapter.js';
-import { getStorageManager } from '../../../src/storageManager.js'
+import { spec, storage } from 'modules/concertBidAdapter.js';
+import { hook } from 'src/hook.js';
 
 describe('ConcertAdapter', function () {
   let bidRequests;
@@ -10,9 +10,8 @@ describe('ConcertAdapter', function () {
   let element;
   let sandbox;
 
-  afterEach(function () {
-    $$PREBID_GLOBAL$$.bidderSettings = {};
-    sandbox.restore();
+  before(function () {
+    hook.ready();
   });
 
   beforeEach(function () {
@@ -39,6 +38,7 @@ describe('ConcertAdapter', function () {
         storageAllowed: true
       }
     };
+
     bidRequests = [
       {
         bidder: 'concert',
@@ -83,6 +83,11 @@ describe('ConcertAdapter', function () {
     sandbox.stub(document, 'getElementById').withArgs('desktop_leaderboard_variable').returns(element)
   });
 
+  afterEach(function () {
+    $$PREBID_GLOBAL$$.bidderSettings = {};
+    sandbox.restore();
+  });
+
   describe('spec.isBidRequestValid', function() {
     it('should return when it recieved all the required params', function() {
       const bid = bidRequests[0];
@@ -118,7 +123,6 @@ describe('ConcertAdapter', function () {
     });
 
     it('should not generate uid if the user has opted out', function() {
-      const storage = getStorageManager();
       storage.setDataInLocalStorage('c_nap', 'true');
       const request = spec.buildRequests(bidRequests, bidRequest);
       const payload = JSON.parse(request.data);
@@ -127,7 +131,6 @@ describe('ConcertAdapter', function () {
     });
 
     it('should generate uid if the user has not opted out', function() {
-      const storage = getStorageManager();
       storage.removeDataFromLocalStorage('c_nap');
       const request = spec.buildRequests(bidRequests, bidRequest);
       const payload = JSON.parse(request.data);
@@ -136,8 +139,8 @@ describe('ConcertAdapter', function () {
     });
 
     it('should grab uid from local storage if it exists', function() {
-      const storage = getStorageManager();
       storage.setDataInLocalStorage('vmconcert_uid', 'foo');
+      console.log('GET', storage.getDataFromLocalStorage('vmconcert_uid'))
       storage.removeDataFromLocalStorage('c_nap');
       const request = spec.buildRequests(bidRequests, bidRequest);
       const payload = JSON.parse(request.data);
@@ -211,7 +214,6 @@ describe('ConcertAdapter', function () {
       const opts = {
         iframeEnabled: true
       };
-      const storage = getStorageManager();
       storage.setDataInLocalStorage('c_nap', 'true');
 
       const sync = spec.getUserSyncs(opts, [], bidRequest.gdprConsent, bidRequest.uspConsent);
@@ -222,7 +224,6 @@ describe('ConcertAdapter', function () {
       const opts = {
         iframeEnabled: true
       };
-      const storage = getStorageManager();
       storage.removeDataFromLocalStorage('c_nap');
 
       bidRequest.gdprConsent = {
@@ -237,7 +238,6 @@ describe('ConcertAdapter', function () {
       const opts = {
         iframeEnabled: true
       };
-      const storage = getStorageManager();
       storage.removeDataFromLocalStorage('c_nap');
 
       bidRequest.gdprConsent = {
@@ -252,7 +252,6 @@ describe('ConcertAdapter', function () {
       const opts = {
         iframeEnabled: true
       };
-      const storage = getStorageManager();
       storage.removeDataFromLocalStorage('c_nap');
 
       bidRequest.gdprConsent = {
@@ -268,7 +267,6 @@ describe('ConcertAdapter', function () {
       const opts = {
         iframeEnabled: true
       };
-      const storage = getStorageManager();
       storage.removeDataFromLocalStorage('c_nap');
 
       bidRequest.gdprConsent = {

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -137,7 +137,7 @@ describe('ConcertAdapter', function () {
 
     it('should grab uid from local storage if it exists', function() {
       const storage = getStorageManager();
-      storage.setDataInLocalStorage('c_uid', 'foo');
+      storage.setDataInLocalStorage('vmconcert_uid', 'foo');
       storage.removeDataFromLocalStorage('c_nap');
       const request = spec.buildRequests(bidRequests, bidRequest);
       const payload = JSON.parse(request.data);

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -140,7 +140,6 @@ describe('ConcertAdapter', function () {
 
     it('should grab uid from local storage if it exists', function() {
       storage.setDataInLocalStorage('vmconcert_uid', 'foo');
-      console.log('GET', storage.getDataFromLocalStorage('vmconcert_uid'))
       storage.removeDataFromLocalStorage('c_nap');
       const request = spec.buildRequests(bidRequests, bidRequest);
       const payload = JSON.parse(request.data);


### PR DESCRIPTION
### Description

[Jira Ticket](https://vmproduct.atlassian.net/browse/RPO-2012?atlOrigin=eyJpIjoiOGFjMmE3YzVmMDJlNDQ5YmE3OTFjOWIzMDVmY2EwNmMiLCJwIjoiaiJ9)

[Related PR in CDS](https://github.com/voxmedia/concert-delivery-system/pull/400)

### Detailed Changes

This PR improves the name-spacing we use in local storage for keeping track of the user ID to be more specific and to avoid potential collisions with vendors. A check has been added to see if a value for the legacy `c_uid` key exists and replaces it with `vmconcert_uid` if so. If neither the legacy or the new key/value exists, we generate a new uid. 

This PR also fixes the broken tests related to localStorage access. 

### Questions
- Does this need to be duplicated for prebid within concert-ads [here](https://github.com/voxmedia/concert-ads/blob/c6c1ef2de7d624cbc0ad575c6cd5f27d5bf36309/src/vendor/prebid-v2/concertBidAdapter.js#L176) and [here](https://github.com/voxmedia/concert-ads/blob/c6c1ef2de7d624cbc0ad575c6cd5f27d5bf36309/src/vendor/prebid-v3/concertBidAdapter.js#L182)?
- ~~Tests related to local storage values are failing here and on the master branch. How long have they been failing and why?~~ FIXED EM