### PR TITLE
RPO-2012: Add check for shared id

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -188,7 +188,7 @@ function getUid(bidderRequest) {
     return false;
   }
 
-  const sharedId = deepAccess(bidderRequest, 'userId.sharedid.id');
+  const sharedId = deepAccess(bidderRequest, 'userId._sharedid.id');
 
   if (sharedId) {
     return sharedId;

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -1,4 +1,4 @@
-import { logWarn, logMessage, debugTurnedOn, generateUUID } from '../src/utils.js';
+import { logWarn, logMessage, debugTurnedOn, generateUUID, deepAccess } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { hasPurpose1Consent } from '../src/utils/gpdr.js';
@@ -186,6 +186,12 @@ export const storage = getStorageManager({bidderCode: BIDDER_CODE});
 function getUid(bidderRequest) {
   if (hasOptedOutOfPersonalization() || !consentAllowsPpid(bidderRequest)) {
     return false;
+  }
+
+  const sharedId = deepAccess(bidderRequest, 'userId.sharedid.id');
+
+  if (sharedId) {
+    return sharedId;
   }
 
   const LEGACY_CONCERT_UID_KEY = 'c_uid';

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -58,7 +58,7 @@ describe('ConcertAdapter', function () {
         page: 'https://www.google.com'
       },
       uspConsent: '1YYY',
-      gdprConsent: {},
+      gdprConsent: {}
     };
 
     bidResponse = {

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -58,7 +58,7 @@ describe('ConcertAdapter', function () {
         page: 'https://www.google.com'
       },
       uspConsent: '1YYY',
-      gdprConsent: {}
+      gdprConsent: {},
     };
 
     bidResponse = {
@@ -138,7 +138,21 @@ describe('ConcertAdapter', function () {
       expect(payload.meta.uid).to.not.equal(false);
     });
 
-    it('should grab uid from local storage if it exists', function() {
+    it('should use sharedid if it exists', function() {
+      storage.removeDataFromLocalStorage('c_nap');
+      const request = spec.buildRequests(bidRequests, {
+        ...bidRequest,
+        userId: {
+          sharedid: {
+            id: '123abc'
+          }
+        }
+      });
+      const payload = JSON.parse(request.data);
+      expect(payload.meta.uid).to.equal('123abc');
+    })
+
+    it('should grab uid from local storage if it exists and sharedid does not', function() {
       storage.setDataInLocalStorage('vmconcert_uid', 'foo');
       storage.removeDataFromLocalStorage('c_nap');
       const request = spec.buildRequests(bidRequests, bidRequest);

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -143,7 +143,7 @@ describe('ConcertAdapter', function () {
       const request = spec.buildRequests(bidRequests, {
         ...bidRequest,
         userId: {
-          sharedid: {
+          _sharedid: {
             id: '123abc'
           }
         }


### PR DESCRIPTION
Adds check for sharedId to satisfy comments made [on this PR to prebid.
](https://github.com/prebid/Prebid.js/pull/9158) Falls back to our original functionality of checking for `vmconcert_id` in local storage or creating/setting one there if it does not yet exist.

Partners will need to update their Prebid configuration to add something similar to this if they wish to use sharedId:
```javascript
pbjs.setConfig({
  userSync: {
    userIds: [
      {
        name: "sharedId",
        storage: {
          type: "cookie",
          name: "_sharedid", // create a cookie with this name
          expires: 365, // expires in 1 years
        },
      },
    ],
  },
});
```
and also add the sharedIdSystem submodule to their build:
```bash
$ gulp build --modules=concertBidAdapter,concertAnalyticsAdapter,sharedIdSystem
```