### PR TITLE
RPO-3152: fixes conditional logic for consent allows function

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -204,10 +204,16 @@ function hasOptedOutOfPersonalization() {
  * @param {BidderRequest} bidderRequest Object which contains any data consent signals
  */
 function consentAllowsPpid(bidderRequest) {
-  const uspConsentAllows =
+  let uspConsentAllows = true;
+
+  // if a us privacy string was provided, but they explicitly opted out
+  if (
     typeof bidderRequest?.uspConsent === 'string' &&
     bidderRequest?.uspConsent[0] === '1' &&
-    bidderRequest?.uspConsent[2].toUpperCase() === 'N';
+    bidderRequest?.uspConsent[2].toUpperCase() === 'Y' // user has opted-out
+  ) {
+    uspConsentAllows = false;
+  }
 
   /*
    * True if the gdprConsent is null-y; or GDPR does not apply; or if purpose 1 consent was given.


### PR DESCRIPTION
Follow up to[ this PR](https://github.com/voxmedia/Prebid.js/pull/12) after realizing that the logic was not quite right. This PR assumes us privacy consent was given unless the user explicitly opted out which accounts for the possibility that a consent string was not provided at all, in which case we assume consent. 