### PR TITLE
[RPO-3262] Update getUid function to check for pubcid and sharedid

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -44,7 +44,7 @@ export const spec = {
         debug: debugTurnedOn(),
         uid: getUid(bidderRequest, validBidRequests),
         optedOut: hasOptedOutOfPersonalization(),
-        adapterVersion: '1.1.1',
+        adapterVersion: '1.2.0',
         uspConsent: bidderRequest.uspConsent,
         gdprConsent: bidderRequest.gdprConsent,
         gppConsent: bidderRequest.gppConsent,

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -149,15 +149,10 @@ describe('ConcertAdapter', function () {
 
     it('should use sharedid if it exists', function() {
       storage.removeDataFromLocalStorage('c_nap');
-      const request = spec.buildRequests(bidRequests, {
-        ...bidRequest,
-        userId: {
-          _sharedid: {
-            id: '123abc'
-          }
-        }
-      });
+      const bidRequestsWithSharedId = [{ ...bidRequests[0], userId: { sharedid: { id: '123abc' } } }]
+      const request = spec.buildRequests(bidRequestsWithSharedId, bidRequest);
       const payload = JSON.parse(request.data);
+
       expect(payload.meta.uid).to.equal('123abc');
     })
 


### PR DESCRIPTION
[Jira ticket](https://vmproduct.atlassian.net/browse/RPO-3262)

>  We have been getting escalating reports from Google that they are receiving too many PPIDs that do not reflect unique users. After digging in to certain domains it does appear that we are setting unique UIDs per prebid request without correctly keeping state with our 1P identifier. We expect that this be a reliable and stable user ID for permutive segmentation as well as frequency capping etc.

As of Prebid.js 7.x, access to local storage must be explicitly set. 

Pubs using our bid adapter need to explicitely set the following in their configs:
```javascript
pbjs.bidderSettings = {
  concert: {
    storageAllowed: true
  }
}
```

On our end, this PR adds additional checks for the depracated pubCommonId way of passing user ids and also updates our check for the new way of doing things using the sharedId. We check for these before moving on to our own implementation which sets a concert specific local storage value. 

Until pubs update their configs to explicitly allow local storage access AND if we are not checking for `pubcid` or `sharedid` values, we will continue to generate a new uid every time. 