### PR TITLE
ConcertBidAdapter: Add TDID

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -49,6 +49,7 @@ export const spec = {
         uspConsent: bidderRequest.uspConsent,
         gdprConsent: bidderRequest.gdprConsent,
         gppConsent: bidderRequest.gppConsent,
+        tdid: getTdid(bidderRequest, validBidRequests),
       }
     };
 
@@ -262,4 +263,12 @@ function getOffset(el) {
       top: rect.top + window.scrollY
     };
   }
+}
+
+function getTdid(bidderRequest, validBidRequests) {
+  if (hasOptedOutOfPersonalization() || !consentAllowsPpid(bidderRequest)) {
+    return;
+  }
+
+  return deepAccess(validBidRequests[0], 'userId.tdid');
 }

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -267,8 +267,8 @@ function getOffset(el) {
 
 function getTdid(bidderRequest, validBidRequests) {
   if (hasOptedOutOfPersonalization() || !consentAllowsPpid(bidderRequest)) {
-    return;
+    return null;
   }
 
-  return deepAccess(validBidRequests[0], 'userId.tdid');
+  return deepAccess(validBidRequests[0], 'userId.tdid') || null;
 }

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -116,7 +116,20 @@ describe('ConcertAdapter', function () {
       expect(payload).to.have.property('meta');
       expect(payload).to.have.property('slots');
 
-      const metaRequiredFields = ['prebidVersion', 'pageUrl', 'screen', 'debug', 'uid', 'optedOut', 'adapterVersion', 'uspConsent', 'gdprConsent', 'gppConsent', 'browserLanguage'];
+      const metaRequiredFields = [
+        'prebidVersion',
+        'pageUrl',
+        'screen',
+        'debug',
+        'uid',
+        'optedOut',
+        'adapterVersion',
+        'uspConsent',
+        'gdprConsent',
+        'gppConsent',
+        'browserLanguage',
+        'tdid'
+      ];
       const slotsRequiredFields = ['name', 'bidId', 'transactionId', 'sizes', 'partnerId', 'slotType'];
 
       metaRequiredFields.forEach(function(field) {
@@ -199,6 +212,31 @@ describe('ConcertAdapter', function () {
       expect(slot.offsetCoordinates.x).to.equal(100)
       expect(slot.offsetCoordinates.y).to.equal(0)
     })
+
+    it('should not pass along tdid if the user has opted out', function() {
+      storage.setDataInLocalStorage('c_nap', 'true');
+      const request = spec.buildRequests(bidRequests, bidRequest);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.meta.tdid).to.be.null;
+    });
+
+    it('should not pass along tdid if USP consent disallows', function() {
+      storage.removeDataFromLocalStorage('c_nap');
+      const request = spec.buildRequests(bidRequests, { ...bidRequest, uspConsent: '1YY' });
+      const payload = JSON.parse(request.data);
+
+      expect(payload.meta.tdid).to.be.null;
+    });
+
+    it('should pass along tdid if the user has not opted out', function() {
+      storage.removeDataFromLocalStorage('c_nap', 'true');
+      const tdid = '123abc';
+      const bidRequestsWithTdid = [{ ...bidRequests[0], userId: { tdid } }]
+      const request = spec.buildRequests(bidRequestsWithTdid, bidRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.meta.tdid).to.equal(tdid);
+    });
   });
 
   describe('spec.interpretResponse', function() {


### PR DESCRIPTION
## Type of change

- [x] Feature

## Description of change

This PR adds to ability to see if a publisher has enabled the [Trade Desk Unified ID](https://docs.prebid.org/dev-docs/modules/userid-submodules/unified.html). If the publisher uses the Unified ID and the user has valid GDPR and USP consent settings then the Concert bid adapter will pass along the value of the `tdid` in the meta object.

## Other information

N.A.
