### PR TITLE
ConcertBidApater: Add schain support

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -57,6 +57,7 @@ export const spec = {
         gdprConsent: bidderRequest.gdprConsent,
         gppConsent: bidderRequest.gppConsent,
         tdid: getTdid(bidderRequest, validBidRequests),
+        schain: getSchain(validBidRequests),
       }
     };
 
@@ -278,4 +279,8 @@ function getTdid(bidderRequest, validBidRequests) {
   }
 
   return deepAccess(validBidRequests[0], 'userId.tdid') || null;
+}
+
+function getSchain(validBidRequests) {
+  return deepAccess(validBidRequests[0], 'schain') || null;
 }

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -246,13 +246,13 @@ describe('ConcertAdapter', function () {
 
     it('should pass along schain object if present', function () {
       const schain = {
-        ver: '1.0',
+        ver: "1.0",
         complete: 1,
         nodes: [
           {
-            asi: 'directseller.com',
-            sid: '00001',
-            rid: 'BidRequest1',
+            asi: "directseller.com",
+            sid: "00001",
+            rid: "BidRequest1",
             hp: 1,
           },
         ],

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -237,6 +237,31 @@ describe('ConcertAdapter', function () {
       const payload = JSON.parse(request.data);
       expect(payload.meta.tdid).to.equal(tdid);
     });
+
+    it('should return null if schain object is not present', function () {
+      const request = spec.buildRequests(bidRequests, bidRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.meta.schain).to.be.null;
+    });
+
+    it('should pass along schain object if present', function () {
+      const schain = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [
+          {
+            asi: 'directseller.com',
+            sid: '00001',
+            rid: 'BidRequest1',
+            hp: 1,
+          },
+        ],
+      };
+      const bidRequestsWithSchain = [{ ...bidRequests[0], schain }]
+      const request = spec.buildRequests(bidRequestsWithSchain, bidRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.meta.schain).to.deep.equal(schain);
+    });
   });
 
   describe('spec.interpretResponse', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

This PR updates the Concert bid adapter to pass along the [`schain` object](https://docs.prebid.org/dev-docs/modules/schain.html) when it is available.
