### PR TITLE
Concert Bid Adapter: Add dealId Property to Bid Responses

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -121,7 +121,8 @@ export const spec = {
         meta: { advertiserDomains: bid && bid.adomain ? bid.adomain : [] },
         creativeId: bid.creativeId,
         netRevenue: bid.netRevenue,
-        currency: bid.currency
+        currency: bid.currency,
+        ...(bid.dealid && { dealId: bid.dealid }),
       };
     });
 

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -251,12 +251,12 @@ describe('ConcertAdapter', function () {
 
     it('should include dealId when present in bidResponse', function() {
       const bids = spec.interpretResponse({ ...bidResponse, dealid: 'CON-123' }, bidRequest);
-      expect(bids).to.have.property('dealId');
+      expect(bids[0]).to.have.property('dealId');
     });
 
     it('should exclude dealId when absent in bidResponse', function() {
       const bids = spec.interpretResponse(bidResponse, bidRequest);
-      expect(bids).to.not.have.property('dealId');
+      expect(bids[0]).to.not.have.property('dealId');
     });
 
     it('should return empty bids if there is no response from server', function() {

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -250,7 +250,13 @@ describe('ConcertAdapter', function () {
     });
 
     it('should include dealId when present in bidResponse', function() {
-      const bids = spec.interpretResponse({ ...bidResponse, dealid: 'CON-123' }, bidRequest);
+      const bids = spec.interpretResponse({
+        body: {
+          bids: [
+            { ...bidResponse.body.bids[0], dealid: 'CON-123' }
+          ]
+        }
+      }, bidRequest);
       expect(bids[0]).to.have.property('dealId');
     });
 

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -249,6 +249,16 @@ describe('ConcertAdapter', function () {
       });
     });
 
+    it('should include dealId when present in bidResponse', function() {
+      const bids = spec.interpretResponse({ ...bidResponse, dealid: 'CON-123' }, bidRequest);
+      expect(bids).to.have.property('dealId');
+    });
+
+    it('should exclude dealId when absent in bidResponse', function() {
+      const bids = spec.interpretResponse(bidResponse, bidRequest);
+      expect(bids).to.not.have.property('dealId');
+    });
+
     it('should return empty bids if there is no response from server', function() {
       const bids = spec.interpretResponse({ body: null }, bidRequest);
       expect(bids).to.have.lengthOf(0);


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 

## Description of change
Conditionally adds `dealId` property to bidResponse objects in the `interpretResponse` method. Intended to be uses as the `hb_deal` targeting property