### PR TITLE
[RPO-4220] Removes Access to Deprecated userId Object

### DIFF
--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -69,7 +69,7 @@ export const spec = {
     }
 
     payload.slots = validBidRequests.map(bidRequest => {
-      collectEid(eids, bidRequest);
+      if (Array.isArray(bidRequest.userIdAsEids) && bidRequest.userIdAsEids !== 0) eids.push(bidRequest.userIdAsEids)
       const adUnitElement = document.getElementById(bidRequest.adUnitCode)
       const coordinates = getOffset(adUnitElement)
 
@@ -90,7 +90,7 @@ export const spec = {
       return slot;
     });
 
-    payload.meta.eids = eids.filter(Boolean);
+    payload.meta.eids = eids;
 
     logMessage(payload);
 
@@ -174,6 +174,8 @@ function getUid(bidderRequest, validBidRequests) {
     return false;
   }
 
+  const eids = validBidRequests[0].userIdAsEids;
+
   /**
    * check for shareId or pubCommonId before generating a new one
    * sharedId: @see https://docs.prebid.org/dev-docs/modules/userId.html
@@ -205,6 +207,10 @@ function getUid(bidderRequest, validBidRequests) {
   }
 
   return uid;
+}
+
+function getUidFromEids() {
+
 }
 
 /**
@@ -240,28 +246,6 @@ function consentAllowsPpid(bidderRequest) {
   const gdprConsentAllows = hasPurpose1Consent(bidderRequest?.gdprConsent);
 
   return (uspConsentAllows && gdprConsentAllows);
-}
-
-function collectEid(eids, bid) {
-  if (bid.userId) {
-    const eid = getUserId(bid.userId.uid2 && bid.userId.uid2.id, 'uidapi.com', undefined, 3)
-    eids.push(eid)
-  }
-}
-
-function getUserId(id, source, uidExt, atype) {
-  if (id) {
-    const uid = { id, atype };
-
-    if (uidExt) {
-      uid.ext = uidExt;
-    }
-
-    return {
-      source,
-      uids: [ uid ]
-    };
-  }
 }
 
 function getOffset(el) {

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -69,7 +69,7 @@ export const spec = {
     }
 
     payload.slots = validBidRequests.map(bidRequest => {
-      eids.push(...(bid.userIdAsEids || []));
+      eids.push(...(bidRequest.userIdAsEids || []));
       const adUnitElement = document.getElementById(bidRequest.adUnitCode);
       const coordinates = getOffset(adUnitElement);
 

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -52,7 +52,7 @@ export const spec = {
         debug: debugTurnedOn(),
         uid: getUid(bidderRequest, validBidRequests),
         optedOut: hasOptedOutOfPersonalization(),
-        adapterVersion: '1.2.0',
+        adapterVersion: '1.3.0',
         uspConsent: bidderRequest.uspConsent,
         gdprConsent: bidderRequest.gdprConsent,
         gppConsent: bidderRequest.gppConsent,

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -1,18 +1,18 @@
-import { logWarn, logMessage, debugTurnedOn, generateUUID, deepAccess } from '../src/utils.js';
-import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { getStorageManager } from '../src/storageManager.js';
-import { hasPurpose1Consent } from '../src/utils/gdpr.js';
-import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
+import { logWarn, logMessage, debugTurnedOn, generateUUID, deepAccess } from "../src/utils.js";
+import { registerBidder } from "../src/adapters/bidderFactory.js";
+import { getStorageManager } from "../src/storageManager.js";
+import { hasPurpose1Consent } from "../src/utils/gdpr.js";
+import { getBoundingClientRect } from "../libraries/boundingClientRect/boundingClientRect.js";
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
  * @typedef {import('../src/adapters/bidderFactory.js').Bid} Bid
  * @typedef {import('../src/adapters/bidderFactory.js').ServerResponse} ServerResponse
- * @typedef {import('../src/adapters/bidderFactory.js').validBidRequests} validBidRequests
+ * @typedef {import('../src/adapters/bidderFactory.js').ServerRequest} ServerRequest
  */
 
-const BIDDER_CODE = 'concert';
-const CONCERT_ENDPOINT = 'https://bids.concert.io';
+const BIDDER_CODE = "concert";
+const CONCERT_ENDPOINT = "https://bids.concert.io";
 
 export const spec = {
   code: BIDDER_CODE,
@@ -20,11 +20,10 @@ export const spec = {
    * Determines whether or not the given bid request is valid.
    *
    * @param {BidRequest} bid The bid params to validate.
-   * @return boolean True if this is a valid bid, and false otherwise.
    */
-  isBidRequestValid: function(bid) {
+  isBidRequestValid: function (bid) {
     if (!bid.params.partnerId) {
-      logWarn('Missing partnerId bid parameter');
+      logWarn("Missing partnerId bid parameter");
       return false;
     }
 
@@ -34,11 +33,11 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
-   * @param {bidderRequest} -
-   * @return ServerRequest Info describing the request to the server.
+   * @param {BidRequest[]} validBidRequests - an array of bids
+   * @param {Object} bidderRequest - the bidder request object
+   * @return {ServerRequest} Info describing the request to the server.
    */
-  buildRequests: function(validBidRequests, bidderRequest) {
+  buildRequests: function (validBidRequests, bidderRequest) {
     logMessage(validBidRequests);
     logMessage(bidderRequest);
 
@@ -46,29 +45,29 @@ export const spec = {
 
     let payload = {
       meta: {
-        prebidVersion: '$prebid.version$',
+        prebidVersion: "$prebid.version$",
         pageUrl: bidderRequest.refererInfo.page,
-        screen: [window.screen.width, window.screen.height].join('x'),
+        screen: [window.screen.width, window.screen.height].join("x"),
         browserLanguage: window.navigator.language,
         debug: debugTurnedOn(),
         uid: getUid(bidderRequest, validBidRequests),
         optedOut: hasOptedOutOfPersonalization(),
-        adapterVersion: '1.2.0',
+        adapterVersion: "1.2.0",
         uspConsent: bidderRequest.uspConsent,
         gdprConsent: bidderRequest.gdprConsent,
         gppConsent: bidderRequest.gppConsent,
         tdid: getTdid(bidderRequest, validBidRequests),
-      }
+      },
     };
 
     if (!payload.meta.gppConsent && bidderRequest.ortb2?.regs?.gpp) {
       payload.meta.gppConsent = {
         gppString: bidderRequest.ortb2.regs.gpp,
-        applicableSections: bidderRequest.ortb2.regs.gpp_sid
+        applicableSections: bidderRequest.ortb2.regs.gpp_sid,
       };
     }
 
-    payload.slots = validBidRequests.map(bidRequest => {
+    payload.slots = validBidRequests.map((bidRequest) => {
       eids.push(...(bidRequest.userIdAsEids || []));
       const adUnitElement = document.getElementById(bidRequest.adUnitCode);
       const coordinates = getOffset(adUnitElement);
@@ -81,10 +80,10 @@ export const spec = {
         partnerId: bidRequest.params.partnerId,
         slotType: bidRequest.params.slotType,
         adSlot: bidRequest.params.slot || bidRequest.adUnitCode,
-        placementId: bidRequest.params.placementId || '',
+        placementId: bidRequest.params.placementId || "",
         site: bidRequest.params.site || bidderRequest.refererInfo.page,
         ref: bidderRequest.refererInfo.ref,
-        offsetCoordinates: { x: coordinates?.left, y: coordinates?.top }
+        offsetCoordinates: { x: coordinates?.left, y: coordinates?.top },
       };
 
       return slot;
@@ -95,9 +94,9 @@ export const spec = {
     logMessage(payload);
 
     return {
-      method: 'POST',
+      method: "POST",
       url: `${CONCERT_ENDPOINT}/bids/prebid`,
-      data: JSON.stringify(payload)
+      data: JSON.stringify(payload),
     };
   },
   /**
@@ -106,19 +105,19 @@ export const spec = {
    * @param {ServerResponse} serverResponse A successful response from the server.
    * @return {Bid[]} An array of bids which were nested inside the server.
    */
-  interpretResponse: function(serverResponse, bidRequest) {
+  interpretResponse: function (serverResponse, bidRequest) {
     logMessage(serverResponse);
     logMessage(bidRequest);
 
     const serverBody = serverResponse.body;
 
-    if (!serverBody || typeof serverBody !== 'object') {
+    if (!serverBody || typeof serverBody !== "object") {
       return [];
     }
 
     let bidResponses = [];
 
-    bidResponses = serverBody.bids.map(bid => {
+    bidResponses = serverBody.bids.map((bid) => {
       return {
         requestId: bid.bidId,
         cpm: bid.cpm,
@@ -144,27 +143,25 @@ export const spec = {
 
   /**
    * Register bidder specific code, which will execute if bidder timed out after an auction
-   * @param {data} Containing timeout specific data
    */
-  onTimeout: function(data) {
-    logMessage('concert bidder timed out');
+  onTimeout: function (data) {
+    logMessage("concert bidder timed out");
     logMessage(data);
   },
 
   /**
    * Register bidder specific code, which will execute if a bid from this bidder won the auction
-   * @param {Bid} The bid that won the auction
+   * @param {Bid} bid The bid that won the auction
    */
-  onBidWon: function(bid) {
-    logMessage('concert bidder won bid');
+  onBidWon: function (bid) {
+    logMessage("concert bidder won bid");
     logMessage(bid);
-  }
-
-}
+  },
+};
 
 registerBidder(spec);
 
-export const storage = getStorageManager({bidderCode: BIDDER_CODE});
+export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
 
 /**
  * Check or generate a UID for the current user.
@@ -178,11 +175,11 @@ function getUid(bidderRequest, validBidRequests) {
 
   if (sharedId) return sharedId;
   if (pubcId) return pubcId;
-  if (deepAccess(validBidRequests[0], 'crumbs.pubcid')) {
-    return deepAccess(validBidRequests[0], 'crumbs.pubcid');
+  if (deepAccess(validBidRequests[0], "crumbs.pubcid")) {
+    return deepAccess(validBidRequests[0], "crumbs.pubcid");
   }
 
-  const CONCERT_UID_KEY = 'vmconcert_uid';
+  const CONCERT_UID_KEY = "vmconcert_uid";
   let uid = storage.getDataFromLocalStorage(CONCERT_UID_KEY);
 
   if (!uid) {
@@ -195,9 +192,9 @@ function getUid(bidderRequest, validBidRequests) {
 
 function getUserIdsFromEids(bid) {
   const sourceMapping = {
-    'sharedid.org': 'sharedId',
-    'pubcid.org': 'pubcId',
-    'adserver.org': 'tdid',
+    "sharedid.org": "sharedId",
+    "pubcid.org": "pubcId",
+    "adserver.org": "tdid",
   };
 
   const defaultUserIds = { sharedId: null, pubcId: null, tdid: null };
@@ -217,24 +214,26 @@ function getUserIdsFromEids(bid) {
  * Whether the user has opted out of personalization.
  */
 function hasOptedOutOfPersonalization() {
-  const CONCERT_NO_PERSONALIZATION_KEY = 'c_nap';
+  const CONCERT_NO_PERSONALIZATION_KEY = "c_nap";
 
-  return storage.getDataFromLocalStorage(CONCERT_NO_PERSONALIZATION_KEY) === 'true';
+  return (
+    storage.getDataFromLocalStorage(CONCERT_NO_PERSONALIZATION_KEY) === "true"
+  );
 }
 
 /**
  * Whether the privacy consent strings allow personalization.
  *
- * @param {BidderRequest} bidderRequest Object which contains any data consent signals
+ * @param {Object} bidderRequest Object which contains any data consent signals
  */
 function consentAllowsPpid(bidderRequest) {
   let uspConsentAllows = true;
 
   // if a us privacy string was provided, but they explicitly opted out
   if (
-    typeof bidderRequest?.uspConsent === 'string' &&
-    bidderRequest?.uspConsent[0] === '1' &&
-    bidderRequest?.uspConsent[2].toUpperCase() === 'Y' // user has opted-out
+    typeof bidderRequest?.uspConsent === "string" &&
+    bidderRequest?.uspConsent[0] === "1" &&
+    bidderRequest?.uspConsent[2].toUpperCase() === "Y" // user has opted-out
   ) {
     uspConsentAllows = false;
   }
@@ -245,7 +244,7 @@ function consentAllowsPpid(bidderRequest) {
    */
   const gdprConsentAllows = hasPurpose1Consent(bidderRequest?.gdprConsent);
 
-  return (uspConsentAllows && gdprConsentAllows);
+  return uspConsentAllows && gdprConsentAllows;
 }
 
 function getOffset(el) {
@@ -253,7 +252,7 @@ function getOffset(el) {
     const rect = getBoundingClientRect(el);
     return {
       left: rect.left + window.scrollX,
-      top: rect.top + window.scrollY
+      top: rect.top + window.scrollY,
     };
   }
 }

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -1,8 +1,8 @@
-import { logWarn, logMessage, debugTurnedOn, generateUUID, deepAccess } from "../src/utils.js";
-import { registerBidder } from "../src/adapters/bidderFactory.js";
-import { getStorageManager } from "../src/storageManager.js";
-import { hasPurpose1Consent } from "../src/utils/gdpr.js";
-import { getBoundingClientRect } from "../libraries/boundingClientRect/boundingClientRect.js";
+import { logWarn, logMessage, debugTurnedOn, generateUUID, deepAccess } from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { hasPurpose1Consent } from '../src/utils/gdpr.js';
+import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -11,8 +11,8 @@ import { getBoundingClientRect } from "../libraries/boundingClientRect/boundingC
  * @typedef {import('../src/adapters/bidderFactory.js').ServerRequest} ServerRequest
  */
 
-const BIDDER_CODE = "concert";
-const CONCERT_ENDPOINT = "https://bids.concert.io";
+const BIDDER_CODE = 'concert';
+const CONCERT_ENDPOINT = 'https://bids.concert.io';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -23,7 +23,7 @@ export const spec = {
    */
   isBidRequestValid: function (bid) {
     if (!bid.params.partnerId) {
-      logWarn("Missing partnerId bid parameter");
+      logWarn('Missing partnerId bid parameter');
       return false;
     }
 
@@ -45,14 +45,14 @@ export const spec = {
 
     let payload = {
       meta: {
-        prebidVersion: "$prebid.version$",
+        prebidVersion: '$prebid.version$',
         pageUrl: bidderRequest.refererInfo.page,
-        screen: [window.screen.width, window.screen.height].join("x"),
+        screen: [window.screen.width, window.screen.height].join('x'),
         browserLanguage: window.navigator.language,
         debug: debugTurnedOn(),
         uid: getUid(bidderRequest, validBidRequests),
         optedOut: hasOptedOutOfPersonalization(),
-        adapterVersion: "1.2.0",
+        adapterVersion: '1.2.0',
         uspConsent: bidderRequest.uspConsent,
         gdprConsent: bidderRequest.gdprConsent,
         gppConsent: bidderRequest.gppConsent,
@@ -80,7 +80,7 @@ export const spec = {
         partnerId: bidRequest.params.partnerId,
         slotType: bidRequest.params.slotType,
         adSlot: bidRequest.params.slot || bidRequest.adUnitCode,
-        placementId: bidRequest.params.placementId || "",
+        placementId: bidRequest.params.placementId || '',
         site: bidRequest.params.site || bidderRequest.refererInfo.page,
         ref: bidderRequest.refererInfo.ref,
         offsetCoordinates: { x: coordinates?.left, y: coordinates?.top },
@@ -94,7 +94,7 @@ export const spec = {
     logMessage(payload);
 
     return {
-      method: "POST",
+      method: 'POST',
       url: `${CONCERT_ENDPOINT}/bids/prebid`,
       data: JSON.stringify(payload),
     };
@@ -111,7 +111,7 @@ export const spec = {
 
     const serverBody = serverResponse.body;
 
-    if (!serverBody || typeof serverBody !== "object") {
+    if (!serverBody || typeof serverBody !== 'object') {
       return [];
     }
 
@@ -145,7 +145,7 @@ export const spec = {
    * Register bidder specific code, which will execute if bidder timed out after an auction
    */
   onTimeout: function (data) {
-    logMessage("concert bidder timed out");
+    logMessage('concert bidder timed out');
     logMessage(data);
   },
 
@@ -154,7 +154,7 @@ export const spec = {
    * @param {Bid} bid The bid that won the auction
    */
   onBidWon: function (bid) {
-    logMessage("concert bidder won bid");
+    logMessage('concert bidder won bid');
     logMessage(bid);
   },
 };
@@ -175,11 +175,11 @@ function getUid(bidderRequest, validBidRequests) {
 
   if (sharedId) return sharedId;
   if (pubcId) return pubcId;
-  if (deepAccess(validBidRequests[0], "crumbs.pubcid")) {
-    return deepAccess(validBidRequests[0], "crumbs.pubcid");
+  if (deepAccess(validBidRequests[0], 'crumbs.pubcid')) {
+    return deepAccess(validBidRequests[0], 'crumbs.pubcid');
   }
 
-  const CONCERT_UID_KEY = "vmconcert_uid";
+  const CONCERT_UID_KEY = 'vmconcert_uid';
   let uid = storage.getDataFromLocalStorage(CONCERT_UID_KEY);
 
   if (!uid) {
@@ -192,9 +192,9 @@ function getUid(bidderRequest, validBidRequests) {
 
 function getUserIdsFromEids(bid) {
   const sourceMapping = {
-    "sharedid.org": "sharedId",
-    "pubcid.org": "pubcId",
-    "adserver.org": "tdid",
+    'sharedid.org': 'sharedId',
+    'pubcid.org': 'pubcId',
+    'adserver.org': 'tdid',
   };
 
   const defaultUserIds = { sharedId: null, pubcId: null, tdid: null };
@@ -214,10 +214,10 @@ function getUserIdsFromEids(bid) {
  * Whether the user has opted out of personalization.
  */
 function hasOptedOutOfPersonalization() {
-  const CONCERT_NO_PERSONALIZATION_KEY = "c_nap";
+  const CONCERT_NO_PERSONALIZATION_KEY = 'c_nap';
 
   return (
-    storage.getDataFromLocalStorage(CONCERT_NO_PERSONALIZATION_KEY) === "true"
+    storage.getDataFromLocalStorage(CONCERT_NO_PERSONALIZATION_KEY) === 'true'
   );
 }
 
@@ -231,9 +231,9 @@ function consentAllowsPpid(bidderRequest) {
 
   // if a us privacy string was provided, but they explicitly opted out
   if (
-    typeof bidderRequest?.uspConsent === "string" &&
-    bidderRequest?.uspConsent[0] === "1" &&
-    bidderRequest?.uspConsent[2].toUpperCase() === "Y" // user has opted-out
+    typeof bidderRequest?.uspConsent === 'string' &&
+    bidderRequest?.uspConsent[0] === '1' &&
+    bidderRequest?.uspConsent[2].toUpperCase() === 'Y' // user has opted-out
   ) {
     uspConsentAllows = false;
   }

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -21,7 +21,7 @@ export const spec = {
    *
    * @param {BidRequest} bid The bid params to validate.
    */
-  isBidRequestValid: function (bid) {
+  isBidRequestValid: function(bid) {
     if (!bid.params.partnerId) {
       logWarn('Missing partnerId bid parameter');
       return false;
@@ -37,7 +37,7 @@ export const spec = {
    * @param {Object} bidderRequest - the bidder request object
    * @return {ServerRequest} Info describing the request to the server.
    */
-  buildRequests: function (validBidRequests, bidderRequest) {
+  buildRequests: function(validBidRequests, bidderRequest) {
     logMessage(validBidRequests);
     logMessage(bidderRequest);
 
@@ -105,7 +105,7 @@ export const spec = {
    * @param {ServerResponse} serverResponse A successful response from the server.
    * @return {Bid[]} An array of bids which were nested inside the server.
    */
-  interpretResponse: function (serverResponse, bidRequest) {
+  interpretResponse: function(serverResponse, bidRequest) {
     logMessage(serverResponse);
     logMessage(bidRequest);
 
@@ -144,7 +144,7 @@ export const spec = {
   /**
    * Register bidder specific code, which will execute if bidder timed out after an auction
    */
-  onTimeout: function (data) {
+  onTimeout: function(data) {
     logMessage('concert bidder timed out');
     logMessage(data);
   },
@@ -153,7 +153,7 @@ export const spec = {
    * Register bidder specific code, which will execute if a bid from this bidder won the auction
    * @param {Bid} bid The bid that won the auction
    */
-  onBidWon: function (bid) {
+  onBidWon: function(bid) {
     logMessage('concert bidder won bid');
     logMessage(bid);
   },

--- a/modules/concertBidAdapter.js
+++ b/modules/concertBidAdapter.js
@@ -216,9 +216,7 @@ function getUserIdsFromEids(bid) {
 function hasOptedOutOfPersonalization() {
   const CONCERT_NO_PERSONALIZATION_KEY = 'c_nap';
 
-  return (
-    storage.getDataFromLocalStorage(CONCERT_NO_PERSONALIZATION_KEY) === 'true'
-  );
+  return storage.getDataFromLocalStorage(CONCERT_NO_PERSONALIZATION_KEY) === 'true';
 }
 
 /**

--- a/test/spec/modules/concertBidAdapter_spec.js
+++ b/test/spec/modules/concertBidAdapter_spec.js
@@ -166,12 +166,18 @@ describe('ConcertAdapter', function () {
 
     it('should use sharedid if it exists', function() {
       storage.removeDataFromLocalStorage('c_nap');
-      const bidRequestsWithSharedId = [{ ...bidRequests[0], userId: { sharedid: { id: '123abc' } } }]
+      const bidRequestsWithSharedId = [{
+        ...bidRequests[0],
+        userIdAsEids: [{
+          source: 'sharedid.org',
+          uids: [{ id: '123abc' }]
+        }]
+      }];
       const request = spec.buildRequests(bidRequestsWithSharedId, bidRequest);
       const payload = JSON.parse(request.data);
 
       expect(payload.meta.uid).to.equal('123abc');
-    })
+    });
 
     it('should grab uid from local storage if it exists and sharedid does not', function() {
       storage.setDataInLocalStorage('vmconcert_uid', 'foo');
@@ -183,7 +189,10 @@ describe('ConcertAdapter', function () {
     });
 
     it('should add uid2 to eids list if available', function() {
-      bidRequests[0].userId = { uid2: { id: 'uid123' } }
+      bidRequests[0].userIdAsEids = [{
+        source: 'uidapi.com',
+        uids: [{ id: 'uid123', atype: 3 }]
+      }];
 
       const request = spec.buildRequests(bidRequests, bidRequest);
       const payload = JSON.parse(request.data);
@@ -195,7 +204,6 @@ describe('ConcertAdapter', function () {
     })
 
     it('should return empty eids list if none are available', function() {
-      bidRequests[0].userId = { testId: { id: 'uid123' } }
       const request = spec.buildRequests(bidRequests, bidRequest);
       const payload = JSON.parse(request.data);
       const meta = payload.meta
@@ -232,10 +240,31 @@ describe('ConcertAdapter', function () {
     it('should pass along tdid if the user has not opted out', function() {
       storage.removeDataFromLocalStorage('c_nap', 'true');
       const tdid = '123abc';
-      const bidRequestsWithTdid = [{ ...bidRequests[0], userId: { tdid } }]
+      const bidRequestsWithTdid = [{
+        ...bidRequests[0],
+        userIdAsEids: [{
+          source: 'adserver.org',
+          uids: [{ id: tdid }]
+        }]
+      }];
       const request = spec.buildRequests(bidRequestsWithTdid, bidRequest);
       const payload = JSON.parse(request.data);
       expect(payload.meta.tdid).to.equal(tdid);
+    });
+
+    it('should use pubcId if it exists and sharedId does not', function() {
+      storage.removeDataFromLocalStorage('c_nap');
+      const bidRequestsWithPubcId = [{
+        ...bidRequests[0],
+        userIdAsEids: [{
+          source: 'pubcid.org',
+          uids: [{ id: 'pubcid123' }]
+        }]
+      }];
+      const request = spec.buildRequests(bidRequestsWithPubcId, bidRequest);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.meta.uid).to.equal('pubcid123');
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 

## Description of change
<!-- Describe the change proposed in this pull request -->
Updates our uid and eid extraction logic to eliminate usage of `bidderRequest.{}.userId` in favor of the new `userIdAsEids` property that will replace it in Prebid 10.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
[Relevant issue](https://github.com/prebid/Prebid.js/issues/11377)